### PR TITLE
Add support for sending an event as json

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Splunk HEC is running on a Heavy Forwarder or single instance. More info abo
     event_host fluentdhost #optional
     source fluentd #optional
     sourcetype data:type #optional
+    send_event_as_json true #optional
 </source>
 ```
 
@@ -56,6 +57,10 @@ Specify the source-field for the event data in Splunk. If you don't specify this
 ## config: sourcetype
 
 Specify the sourcetype-field for the event data in Splunk. If you don't specify this the plug-in will use the tag from the FluentD input plug-in.
+
+## config: send_event_as_json
+
+Specify if an event should be sent as json rather than as a string. Can be 'true' or 'false'. If you don't specify then this will be 'false'.
 
 ## Contributing
 


### PR DESCRIPTION
Currently if you pass json to the plugin then it will quote the json before sending to the HEC so Splunk sees it as a string.

This change allows you to specify the event as json so Splunk sees it as json and correctly breaks out the fields.  More on event data: http://dev.splunk.com/view/event-collector/SP-CAAAE6P

