### PR TITLE
Add raw logs to Splunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The Splunk HEC is running on a Heavy Forwarder or single instance. More info abo
     event_host fluentdhost #optional
     source fluentd #optional
     sourcetype data:type #optional
+    usejson true #optional defaults to true
 </source>
 ```
 
@@ -56,6 +57,10 @@ Specify the source-field for the event data in Splunk. If you don't specify this
 ## config: sourcetype
 
 Specify the sourcetype-field for the event data in Splunk. If you don't specify this the plug-in will use the tag from the FluentD input plug-in.
+
+## config: usejson
+
+Specify the event type as JSON (true|default) or raw (false) for sending Log4J messages so Splunk so it can parse the time field it self based on the format 'time' regex match found in the source, uses millisecond precision.
 
 ## Contributing
 

--- a/lib/fluent/plugin/out_splunkhec.rb
+++ b/lib/fluent/plugin/out_splunkhec.rb
@@ -86,8 +86,8 @@ module Fluent
           if @usejson == 'true'
             body = '{"time" :' + time.to_s + ', "event" :"' + event + '", "sourcetype" :"' + @event_sourcetype + '", "source" :"' + @event_source + '", "index" :"' + @event_index + '", "host" : "' + @event_host + '"}'
           else
-            event = record["time"] + record["message"]
-            body = '{"time":"'+ DateTime.parse(record["time"]).strftime("%Q") +'", "event":"' + event.to_s + '", "sourcetype" :"' + @event_sourcetype + '", "source" :"' + @event_source + '", "index" :"' + @event_index + '", "host" : "' + @event_host + '"}'
+            event = record["time"]+ " " + record["message"].to_json.gsub(/^"|"$/,"")
+            body = '{"time":"'+ DateTime.parse(record["time"]).strftime("%Q") +'", "event":"' + event + '", "sourcetype" :"' + @event_sourcetype + '", "source" :"' + @event_source + '", "index" :"' + @event_index + '", "host" : "' + @event_host + '"}'
           end
           log.debug "splunkhec: " + body + "\n"
           


### PR DESCRIPTION
I've added a `usejson` config parameter (default to true) which can be set to `false` which will allow the parser to add a `time` entry either from the `<source>` from a named format regex or a filter before the splunkhec `<match ...>`.

My company is looking into fluent collectors for many reasons and we use Splunk and Log4J (lots of Java) with millisecond precission eg `%Y-%m-%d %H:%M:%S,%3N` in our log entries. This needs to be preserved in Splunk as the latency and lack of precision from fluentd or the plugin is not usable.

I'm not a ruby guy so perhaps a review would be in order!