### PR TITLE
Feature/send batched events

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The Splunk HEC is running on a Heavy Forwarder or single instance. More info abo
     sourcetype data:type #optional
     usejson true #optional defaults to true
     send_event_as_json true #optional
+    send_batched_events false #optional
 </source>
 ```
 
@@ -66,6 +67,10 @@ Specify if an event should be sent as json rather than as a string. Can be 'true
 ## config: usejson
 
 Specify the event type as JSON (true|default) or raw (false) for sending Log4J messages so Splunk so it can parse the time field it self based on the format 'time' regex match found in the source, uses millisecond precision.
+
+## config: send_batched_events
+
+Specify that all events in a FluentD chunk should be sent in batch to Splunk. Defaults to 'false' which sends one event at a time. Batching events will reduce the load on the Splunk HEC. Max chunk size is controlled by config parameter 'buffer_chunk_limit' and should be matched by the Splunk limit 'max_content_length'. Please see this [blog post](https://www.splunk.com/blog/2016/08/12/handling-http-event-collector-hec-content-length-too-large-errors-without-pulling-your-hair-out.html) for details.
 
 ## Contributing
 

--- a/fluent-plugin-splunkhec.gemspec
+++ b/fluent-plugin-splunkhec.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency "json", '~> 2.0', '>= 2.0.2'
   gem.add_development_dependency "rake", '~> 0.9', '>= 0.9.2'
   gem.add_development_dependency "test-unit", '~> 3.1', '>= 3.1.0'
+  gem.add_development_dependency "webmock", '>= 3.0'
   gem.license = 'MIT'
 end

--- a/lib/fluent/plugin/out_splunkhec.rb
+++ b/lib/fluent/plugin/out_splunkhec.rb
@@ -14,7 +14,7 @@ module Fluent
 
     # Splunk event parameters
     config_param :index,               :string, :default => 'main'
-    config_param :event_host,          :string, :default => `hostname`.delete!("\n")
+    config_param :event_host,          :string, :default => nil
     config_param :source,              :string, :default => 'fluentd'
     config_param :sourcetype,          :string, :default => 'tag'
     config_param :send_event_as_json,  :bool,   :default => false
@@ -28,6 +28,14 @@ module Fluent
       super
       @splunk_url = @protocol + '://' + @host + ':' + @port + '/services/collector/event'
       log.debug 'splunkhec: sent data to ' + @splunk_url
+
+      if conf['event_host'] == nil
+        begin
+          @event_host = `hostname`.delete!("\n")
+        rescue
+          @event_host = 'unknown'
+        end
+      end
     end
 
     def start

--- a/test/plugin/test_out_splunkhec.rb
+++ b/test/plugin/test_out_splunkhec.rb
@@ -36,7 +36,7 @@ class SplunkHECOutputTest < Test::Unit::TestCase
   end
 
   def test_should_require_mandatory_parameter_token
-    assert_raise RuntimeError do
+    assert_raise Fluent::ConfigError do
       create_driver_splunkhec(%[])
     end
   end
@@ -49,9 +49,9 @@ class SplunkHECOutputTest < Test::Unit::TestCase
     assert_equal 'main', d.instance.index
     assert_equal `hostname`.delete!("\n"), d.instance.event_host
     assert_equal 'fluentd', d.instance.source
-    assert_equal nil, d.instance.sourcetype
-    assert_equal "false", d.instance.send_event_as_json
-    assert_equal "true", d.instance.usejson
+    assert_equal 'tag', d.instance.sourcetype
+    assert_equal false, d.instance.send_event_as_json
+    assert_equal true, d.instance.usejson
     assert_equal 'some_token', d.instance.token
   end
 

--- a/test/plugin/test_out_splunkhec.rb
+++ b/test/plugin/test_out_splunkhec.rb
@@ -1,28 +1,146 @@
 require 'helper'
+require 'webmock/test_unit'
+
 
 class SplunkHECOutputTest < Test::Unit::TestCase
-  def setup
-    Fluent::Test.setup
-  end
+  HOST = 'splunk.example.com'
+  PROTOCOL = 'https'
+  PORT = '8443'
+  TOKEN = 'BAB747F3-744E-41BA'
+  SOURCE = 'fluentd'
+  INDEX = 'main'
+  EVENT_HOST = 'some_host'
+  SOURCETYPE = 'log'
+
+  SPLUNK_URL = "#{PROTOCOL}://#{HOST}:#{PORT}/services/collector/event"
 
   ### for Splunk HEC
-  CONFIG_SPLUNKHEC = %[
-    host splunk.bluefactory.nl
-    protocol https
-    port 8443
-    token BAB747F3-744E-41BA
+  CONFIG = %[
+    host #{HOST}
+    protocol #{PROTOCOL}
+    port #{PORT}
+    token #{TOKEN}
+    source #{SOURCE}
+    index #{INDEX}
+    event_host #{EVENT_HOST}
   ]
 
-  def create_driver_splunkhec(conf = CONFIG_SPLUNKHEC)
-    Fluent::Test::InputTestDriver.new(Fluent::SplunkHECOutput).configure(conf)
+  def create_driver_splunkhec(conf = CONFIG)
+    Fluent::Test::BufferedOutputTestDriver.new(Fluent::SplunkHECOutput).configure(conf)
   end
 
-  def test_configure_splunkhec
+  def setup
+    Fluent::Test.setup
+    require 'fluent/plugin/out_splunkhec'
+    stub_request(:any, SPLUNK_URL)
+  end
+
+  def test_should_require_mandatory_parameter_token
+    assert_raise RuntimeError do
+      create_driver_splunkhec(%[])
+    end
+  end
+
+  def test_should_use_default_values_for_optional_parameters
+    d = create_driver_splunkhec(%[token some_token])
+    assert_equal 'localhost', d.instance.host
+    assert_equal 'http', d.instance.protocol
+    assert_equal '8088', d.instance.port
+    assert_equal 'main', d.instance.index
+    assert_equal `hostname`.delete!("\n"), d.instance.event_host
+    assert_equal 'fluentd', d.instance.source
+    assert_equal nil, d.instance.sourcetype
+    assert_equal "false", d.instance.send_event_as_json
+    assert_equal "true", d.instance.usejson
+    assert_equal 'some_token', d.instance.token
+  end
+
+  def test_should_configure_splunkhec
     d = create_driver_splunkhec
-    assert_equal 'splunk.bluefactory.nl', d.instance.host
-    assert_equal 'https' , d.instance.protocol
-    assert_equal '8443' , d.instance.port
-    assert_equal 'BAB747F3-744E-41BA', d.instance.token
+    assert_equal HOST, d.instance.host
+    assert_equal PROTOCOL, d.instance.protocol
+    assert_equal PORT, d.instance.port
+    assert_equal TOKEN, d.instance.token
+  end
+
+  def test_should_post_formatted_event_to_splunk
+    sourcetype = 'log'
+    time = 123456
+    record = {'message' => 'data'}
+
+    splunk_request = stub_request(:post, SPLUNK_URL)
+                         .with(
+                             headers: {
+                                 'Authorization' => "Splunk #{TOKEN}",
+                                 'Content-Type' => 'application/json; charset=utf-8'
+                             },
+                             body: {
+                                 'time' => time,
+                                 'event' => record.to_json,
+                                 'sourcetype' => sourcetype,
+                                 'source' => SOURCE,
+                                 'index' => INDEX,
+                                 'host' => EVENT_HOST
+                             })
+
+    d = create_driver_splunkhec(CONFIG + %[sourcetype #{sourcetype}])
+    d.run do
+      d.emit(record, time)
+    end
+
+    assert_requested(splunk_request)
+  end
+
+  def test_should_use_tag_as_sourcetype_when_configured
+    splunk_request = stub_request(:post, SPLUNK_URL).with(body: hash_including({'sourcetype' => 'test'}))
+
+    d = create_driver_splunkhec(CONFIG + %[sourcetype tag])
+    d.run do
+      d.emit({'message' => 'data'}, 123456)
+    end
+
+    assert_requested(splunk_request)
+  end
+
+  def test_should_send_event_as_string_as_default
+    record = {'message' => 'data'}
+    splunk_request = stub_request(:post, SPLUNK_URL).with(body: hash_including({'event' => record.to_json}))
+
+    d = create_driver_splunkhec(CONFIG + %[send_event_as_json false])
+    d.run do
+      d.emit(record)
+    end
+
+    assert_requested(splunk_request)
+  end
+
+  def test_should_send_event_as_log4j_format_when_configured
+    log_time = '2017-07-02 20:52:39'
+    log_time_millis = '1499028759000'
+    log_event = 'data'
+
+    splunk_request = stub_request(:post, SPLUNK_URL)
+                         .with(body: hash_including({'time' => log_time_millis, 'event' => "#{log_time} #{log_event}"}))
+
+    d = create_driver_splunkhec(CONFIG + %[usejson false])
+    d.run do
+      d.emit({'time' => log_time, 'message' => log_event})
+    end
+
+    assert_requested(splunk_request)
+  end
+
+  def test_should_send_event_as_json_when_configured
+    record = {'message' => 'data'}
+
+    splunk_request = stub_request(:post, SPLUNK_URL).with(body: hash_including({'event' => record}))
+
+    d = create_driver_splunkhec(CONFIG + %[send_event_as_json true])
+    d.run do
+      d.emit(record)
+    end
+
+    assert_requested(splunk_request)
   end
 
 end


### PR DESCRIPTION
Thanks for sharing this plugin!

This pull request adds the capability to batch post all events in a chunk to Splunk HEC. This is more efficient and reduces the load on Splunk HEC. For us, this has avoided Splunk HEC capacity problems that previously caused errors and lost log events.

I also improved the unit test coverage to avoid unintentionally breaking existing functionality.
