### PR TITLE
 In case of errors, raise exception for fluentd to retry

### DIFF
--- a/test/plugin/test_out_splunkhec.rb
+++ b/test/plugin/test_out_splunkhec.rb
@@ -162,4 +162,15 @@ class SplunkHECOutputTest < Test::Unit::TestCase
     assert_requested(splunk_request)
   end
 
+  def test_should_raise_exception_when_splunk_returns_error_to_make_fluentd_retry_later
+    stub_request(:any, SPLUNK_URL).to_return(status: 403, body: {'text' => 'Token disabled', 'code' => 1}.to_json)
+
+    assert_raise Fluent::SplunkHECOutputError do
+      d = create_driver_splunkhec
+      d.run do
+        d.emit({'message' => 'data'})
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
We noticed that when Splunk temporarily fails to receive events, the events would be lost.

This change raises an exception when this happens, causing fluentd to keep the chunk in the queue and retry later according to configuration (see https://docs.fluentd.org/v0.12/articles/buffer-plugin-overview#buffer-structure).