### PR TITLE
Fixed undefined conversion error from ASCII-8BIT to UTF-8 

### DIFF
--- a/fluent-plugin-splunkhec.gemspec
+++ b/fluent-plugin-splunkhec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  gem.add_dependency "json", '~> 2.0', '>= 2.0.2'
+  gem.add_dependency "yajl", '>= 0.3'
   gem.add_development_dependency "rake", '~> 0.9', '>= 0.9.2'
   gem.add_development_dependency "test-unit", '~> 3.1', '>= 3.1.0'
   gem.add_development_dependency "webmock", '>= 3.0'

--- a/lib/fluent/plugin/out_splunkhec.rb
+++ b/lib/fluent/plugin/out_splunkhec.rb
@@ -1,6 +1,6 @@
 require 'fluent/output'
 require 'net/http'
-require 'json'
+require 'yajl/json_gem'
 
 module Fluent
   class SplunkHECOutput < BufferedOutput

--- a/test/plugin/test_out_splunkhec.rb
+++ b/test/plugin/test_out_splunkhec.rb
@@ -173,4 +173,17 @@ class SplunkHECOutputTest < Test::Unit::TestCase
     end
   end
 
+  def test_should_handle_ascii_8bit_encoded_message_with_utf8_chars_correctly
+    record = {'message' => "\xC2\xA92017".b}
+
+    splunk_request = stub_request(:post, SPLUNK_URL).with(body: hash_including({'event' => {'message' => '©2017'}}))
+
+    d = create_driver_splunkhec(CONFIG + %[send_event_as_json true])
+    d.run do
+      d.emit(record)
+    end
+
+    assert_requested(splunk_request)
+  end
+
 end


### PR DESCRIPTION
by swapping json gem for yajl (as used by fluentd).

This fixes the following type of error:

`2017-10-13 13:22:49 +0200 fluent.warn: {"next_retry":"2017-10-13 13:25:11 +0200","error_class":"Encoding::UndefinedConversionError","error":"\"\\xC2\" from ASCII-8BIT to UTF-8","plugin_id":"object:1a0dbf0","message":"temporarily failed to flush the buffer. next_retry=2017-10-13 13:25:11 +0200 error_class=\"Encoding::UndefinedConversionError\" error=\"\\\"\\\\xC2\\\" from ASCII-8BIT to UTF-8\" plugin_id=\"object:1a0dbf0\""}
`