### PR TITLE
changed yajl dependency to yajl-ruby 1.3.0 or above

### DIFF
--- a/fluent-plugin-splunkhec.gemspec
+++ b/fluent-plugin-splunkhec.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   
   gem.add_dependency "fluentd", [">= 0.10.58", "< 2"]
-  gem.add_dependency "yajl", '>= 0.3'
+  gem.add_dependency "yajl-ruby", '>= 1.3.0'
   gem.add_development_dependency "rake", '~> 0.9', '>= 0.9.2'
   gem.add_development_dependency "test-unit", '~> 3.1', '>= 3.1.0'
   gem.add_development_dependency "webmock", '>= 3.0'


### PR DESCRIPTION
Re #14 it seems the gem dependency should be towards yajl-ruby, not yajl. 

Thanks @adrianlzt for making me aware of this.