### PR TITLE
Fix HTTP post requests and Source/Sourcetype

### DIFF
--- a/lib/fluent/plugin/out_splunkhec.rb
+++ b/lib/fluent/plugin/out_splunkhec.rb
@@ -15,8 +15,8 @@ module Fluent
     # Splunk event parameters
     config_param :index,               :string, :default => 'main'
     config_param :event_host,          :string, :default => nil
-    config_param :source,              :string, :default => 'fluentd'
-    config_param :sourcetype,          :string, :default => 'tag'
+    config_param :source,              :string, :default => 'tag'
+    config_param :sourcetype,          :string, :default => 'fluentd'
     config_param :send_event_as_json,  :bool,   :default => false
     config_param :usejson,             :bool,   :default => true
     config_param :send_batched_events, :bool,   :default => false
@@ -69,17 +69,17 @@ module Fluent
         else
           event = record
         end
-
-        sourcetype = @sourcetype == 'tag' ? tag : @sourcetype
+        
+        source = @source == 'tag' ? tag : @source
 
         # Build body for the POST request
         if !@usejson
           event = record["time"]+ " " + record["message"].to_json.gsub(/^"|"$/,"")
           body << '{"time":"'+ DateTime.parse(record["time"]).strftime("%Q") +'", "event":"' + event + '", "sourcetype" :"' + sourcetype + '", "source" :"' + @source + '", "index" :"' + @index + '", "host" : "' + @event_host + '"}'
         elsif @send_event_as_json
-          body << '{"time" :' + time.to_s + ', "event" :' + event + ', "sourcetype" :"' + sourcetype + '", "source" :"' + @source + '", "index" :"' + @index + '", "host" : "' + @event_host + '"}'
+          body << '{"time" :' + time.to_s + ', "event" :' + event + ', "sourcetype" :"' + sourcetype + '", "source" :"' + source + '", "index" :"' + @index + '", "host" : "' + @event_host + '"}'
         else
-          body << '{"time" :' + time.to_s + ', "event" :"' + event + '", "sourcetype" :"' + sourcetype + '", "source" :"' + @source + '", "index" :"' + @index + '", "host" : "' + @event_host + '"}'
+          body << '{"time" :' + time.to_s + ', "event" :"' + event + '", "sourcetype" :"' + sourcetype + '", "source" :"' + source + '", "index" :"' + @index + '", "host" : "' + @event_host + '"}'
         end
 
         if @send_batched_events


### PR DESCRIPTION
Hey @cmeerbeek !

Thanks for creating this plugin! I've got two commits here:


* make http post to Splunk HEC work:
For some reason when using it for the first time I was getting "Code 5 - No Data" from Splunk (fluetnd -> AWS LB -> Splunk HEC). I then tried sending output to Mockbin, where I saw that indeed no data was being sent, just the headers. I'm not very familiar with ruby, but this attempt to fix it actually seems to work, I'm now getting data in Splunk :)

* fix source/sourcetype
This one is more about Splunk terminology, however is a crucial fix for the correct operation of Splunk. AFAIK fluentd's 'tag' is most often being expanded either to the full path of the log file, or set  to the name of the app - both are ideal candidates for Splunk's 'source' field, but not 'sourcetype':

https://docs.splunk.com/Documentation/Splunk/7.0.3/Data/Aboutdefaultfields#Source_vs_sourcetype:
```
The source is the name of the file, stream, or other input from which a particular event originates.
The sourcetype determines how Splunk software processes the incoming data stream into individual events according to the nature of the data.
```

Let me know what you think!