### PR TITLE
Do not skip TLS verification, use existing http context fixes #21

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm:
+  - 2.4
+script:
+  - "bundle exec rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,62 @@
+PATH
+  remote: .
+  specs:
+    fluent-plugin-splunkhec (1.5)
+      fluentd (>= 0.10.58, < 2)
+      yajl-ruby (>= 1.3.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    cool.io (1.5.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
+    dig_rb (1.0.1)
+    fluentd (1.2.0)
+      cool.io (>= 1.4.5, < 2.0.0)
+      dig_rb (~> 1.0.0)
+      http_parser.rb (>= 0.5.1, < 0.7.0)
+      msgpack (>= 0.7.0, < 2.0.0)
+      serverengine (>= 2.0.4, < 3.0.0)
+      sigdump (~> 0.2.2)
+      strptime (>= 0.2.2, < 1.0.0)
+      tzinfo (~> 1.0)
+      tzinfo-data (~> 1.0)
+      yajl-ruby (~> 1.0)
+    hashdiff (0.3.7)
+    http_parser.rb (0.6.0)
+    msgpack (1.2.4)
+    power_assert (1.1.1)
+    public_suffix (3.0.2)
+    rake (0.9.6)
+    safe_yaml (1.0.4)
+    serverengine (2.0.6)
+      sigdump (~> 0.2.2)
+    sigdump (0.2.4)
+    strptime (0.2.3)
+    test-unit (3.2.7)
+      power_assert
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2018.5)
+      tzinfo (>= 1.0.0)
+    webmock (3.4.1)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
+    yajl-ruby (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fluent-plugin-splunkhec!
+  rake (~> 0.9, >= 0.9.2)
+  test-unit (~> 3.1, >= 3.1.0)
+  webmock (>= 3.0)
+
+BUNDLED WITH
+   1.16.1

--- a/lib/fluent/plugin/out_splunkhec.rb
+++ b/lib/fluent/plugin/out_splunkhec.rb
@@ -58,7 +58,7 @@ module Fluent
       chunk.msgpack_each {|(tag,time,record)|
         # Parse record to Splunk event format
         case record
-        when Fixnum
+        when Integer
           event = record.to_s
         when Hash
           if @send_event_as_json
@@ -69,7 +69,7 @@ module Fluent
         else
           event = record
         end
-        
+
         source = @source == 'tag' ? tag : @source
 
         # Build body for the POST request
@@ -104,19 +104,16 @@ module Fluent
       http = Net::HTTP.new(uri.host, uri.port)
 
       # Create request
-      req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json", "Authorization" => "Splunk #{@token}")
+      req = Net::HTTP::Post.new(uri, "Content-Type" => "application/json; charset=utf-8", "Authorization" => "Splunk #{@token}")
       req.body = body
 
       # Handle SSL
       if @protocol == 'https'
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       end
 
       # Send Request
-      res = Net::HTTP.start(uri.hostname, uri.port) do |http|
-        http.request(req)
-      end
+      res = http.request(req)
 
       log.debug "splunkhec: HTTP Response Status Code is #{res.code}"
 

--- a/test/plugin/test_out_splunkhec.rb
+++ b/test/plugin/test_out_splunkhec.rb
@@ -48,8 +48,8 @@ class SplunkHECOutputTest < Test::Unit::TestCase
     assert_equal '8088', d.instance.port
     assert_equal 'main', d.instance.index
     assert_equal `hostname`.delete!("\n"), d.instance.event_host
-    assert_equal 'fluentd', d.instance.source
-    assert_equal 'tag', d.instance.sourcetype
+    assert_equal 'fluentd', d.instance.sourcetype
+    assert_equal 'tag', d.instance.source
     assert_equal false, d.instance.send_event_as_json
     assert_equal true, d.instance.usejson
     assert_equal false, d.instance.send_batched_events
@@ -73,7 +73,7 @@ class SplunkHECOutputTest < Test::Unit::TestCase
                          .with(
                              headers: {
                                  'Authorization' => "Splunk #{TOKEN}",
-                                 'Content-Type' => 'application/json; charset=utf-8'
+                                 'Content-Type' => 'application/json; charset=utf-8',
                              },
                              body: {
                                  'time' => time,
@@ -95,7 +95,7 @@ class SplunkHECOutputTest < Test::Unit::TestCase
   def test_should_use_tag_as_sourcetype_when_configured
     splunk_request = stub_request(:post, SPLUNK_URL).with(body: hash_including({'sourcetype' => 'test'}))
 
-    d = create_driver_splunkhec(CONFIG + %[sourcetype tag])
+    d = create_driver_splunkhec(CONFIG + %[sourcetype test])
     d.run do
       d.emit({'message' => 'data'}, 123456)
     end


### PR DESCRIPTION
* Adding Gemfile lock for deterministic builds
* Making tests to pass
* Do not skip TLS (OpenSSL::SSL::VERIFY_NONE ignores certificate validation)
* Fixed warning around Fixnum usage
Following recommendation from https://bugs.ruby-lang.org/issues/12005